### PR TITLE
Added VAE Download to tool download kit

### DIFF
--- a/tools/download_weights.py
+++ b/tools/download_weights.py
@@ -106,5 +106,6 @@ if __name__ == '__main__':
     prepare_base_model()
     prepare_image_encoder()
     prepare_dwpose()
+    prepare_vae()
     prepare_anyone()
     


### PR DESCRIPTION
See #43 

While running 

`python tools/download_weights.py`

I noticed the vae wasn't installing — the function call for it was missing in `tools/download_weights.py`

I just added the function call within the main

Cheers!