### PR TITLE
fix mutual_self_attention.py bug

### DIFF
--- a/src/models/mutual_self_attention.py
+++ b/src/models/mutual_self_attention.py
@@ -45,8 +45,8 @@ class ReferenceAttentionControl:
             style_fidelity,
             reference_attn,
             reference_adain,
-            fusion_blocks,
             batch_size=batch_size,
+            fusion_blocks=fusion_blocks,
         )
 
     def register_reference_hooks(


### PR DESCRIPTION
Fix the bug where the value of `fusion_blocks` is always set to "midup".